### PR TITLE
Build the client and server with the same npm command

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ cp presets.json.template presets.json
 cp alerts.json.template alerts.json
 npm install
 npm run build
-npm run build-server
 node build/server.js
 ```
 

--- a/package.json
+++ b/package.json
@@ -24,8 +24,9 @@
     "winston": "^3.2.1"
   },
   "scripts": {
-    "start": "react-scripts start",
-    "build": "react-scripts build",
+    "start": "export PORT=3001 && react-scripts start",
+    "build": "npm run 'build-client' && npm run build-server",
+    "build-client": "react-scripts build",
     "start-server": "node build/server.js",
     "build-server": "tsc --project tsconfig.server.json --jsx react",
     "test": "react-scripts test --env=jsdom",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "scripts": {
     "start": "export PORT=3001 && react-scripts start",
-    "build": "npm run 'build-client' && npm run build-server",
+    "build": "npm run build-client && npm run build-server",
     "build-client": "react-scripts build",
     "start-server": "node build/server.js",
     "build-server": "tsc --project tsconfig.server.json --jsx react",


### PR DESCRIPTION
**Earlier:**

- `npm run build` builds the react application
- `npm run build-server` builds the express/socket.io server

**Now:**

- `npm run build-client` builds the react application
- `npm run build-server` builds the express/socket.io server
- `npm run build` builds both the react application and express/socket.io server

Additionally, run `react-scripts start` on port 3001 since the server runs on port 3000

Resolves #29