### PR TITLE
Use SVG-based icons

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8952,6 +8952,11 @@
         "safe-buffer": "^5.1.2"
       }
     },
+    "mdi-react": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/mdi-react/-/mdi-react-7.3.0.tgz",
+      "integrity": "sha512-pG7nAhzUMHzlI/6jRMvyujMSpuM93gGcTIirpQBYq5zheNf6MkqR4BAMWcwWnK5759MRBqgTusbQm1YHnkJe9Q=="
+    },
     "mdn-data": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-1.1.4.tgz",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "express": "^4.16.4",
     "i18next": "^15.0.7",
     "i18next-browser-languagedetector": "^3.0.1",
+    "mdi-react": "^7.3.0",
     "react": "^16.8.2",
     "react-dom": "^16.8.2",
     "react-i18next": "^10.5.1",

--- a/src/components/PresetEditor/PresetEditorTurn.tsx
+++ b/src/components/PresetEditor/PresetEditorTurn.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+import DragIcon from "mdi-react/DragIcon";
 import Player from "../../constants/Player";
 import PlayerTurnSettings from "./PlayerTurnSettings";
 import Turn from "../../models/Turn";
@@ -13,7 +14,7 @@ interface IProps {
 export const PresetEditorTurn = ({index, turn, onValueChange, className, ...otherProps}: IProps) =>
     <div className={className} {...otherProps}>
         <div className="column is-1 has-text-vcentered is-size-5 has-text-grey has-text-left">
-            <i className="material-icons has-text-grey has-cursor-grab is-drag-handle is-size-3">drag_indicator</i>
+            <DragIcon className="has-text-grey has-cursor-grab is-drag-handle is-size-3" />
             {index + 1}</div>
         <div className="column has-text-centered">
             <PlayerTurnSettings player={Player.HOST} turn={turn} key={'host-' + index} index={index}/>

--- a/src/components/draft/Draft.tsx
+++ b/src/components/draft/Draft.tsx
@@ -9,6 +9,7 @@ import "../../types/DraftEvent";
 import {DraftEvent} from "../../types/DraftEvent";
 import {IDraftConfig} from "../../types/IDraftConfig";
 import {Trans, WithTranslation, withTranslation} from "react-i18next";
+import KeyboardBackspaceIcon from "mdi-react/KeyboardBackspaceIcon";
 import Modal from "../../containers/Modal";
 import NameGenerator from "../../util/NameGenerator";
 import {withRouter} from "react-router-dom";
@@ -110,7 +111,7 @@ class Draft extends React.Component<IProps, IState> {
                     <div className="columns is-mobile">
                         <div className="column is-1 py-0">
                                 <a onClick={this.disconnectAndGoBack} aria-label="Go back" className="back-icon header-navigation">
-                                    <i className="material-icons">keyboard_backspace</i>
+                                    <KeyboardBackspaceIcon size={48} />
                                 </a>
                         </div>
                         <div className="column content my-0">

--- a/src/components/draft/ReplayControls.tsx
+++ b/src/components/draft/ReplayControls.tsx
@@ -2,6 +2,10 @@ import * as React from "react";
 import Preset from "../../models/Preset";
 import "../../types/DraftEvent";
 import {WithTranslation, withTranslation} from "react-i18next";
+import PauseIcon from "mdi-react/PauseIcon";
+import PlayArrowIcon from "mdi-react/PlayArrowIcon";
+import SkipNextIcon from "mdi-react/SkipNextIcon";
+import FastForwardIcon from "mdi-react/FastForwardIcon";
 import {Util} from "../../util/Util";
 import Player from "../../constants/Player";
 import {DraftEvent} from "../../types/DraftEvent";
@@ -48,18 +52,19 @@ class ReplayControls extends React.Component<IProps, IState> {
         if (this.props.replayEvents.length === 0 || this.hasDraftEnded()) {
             return null;
         }
+
         const pauseButton = <button id="spectator-pause" className="spectator-action button is-large"
                                     onClick={this.haltReplay} aria-label="Pause">
-            <i className="material-icons">pause</i></button>;
+            <PauseIcon size={48} /></button>;
         const runButton = <button id="spectator-play" className="spectator-action button is-large"
                                   onClick={this.runReplay} aria-label="Play">
-            <i className="material-icons">play_arrow</i></button>;
+            <PlayArrowIcon size={48} /></button>;
         const nextButton = <button id="spectator-next" className="spectator-action button is-large"
                                    onClick={this.nextStep} aria-label="Next">
-            <i className="material-icons">skip_next</i></button>;
+            <SkipNextIcon size={48} /></button>;
         const skipToEndbutton = <button id="spectator-forward" className="spectator-action button is-large"
                                         onClick={this.skipToEnd} aria-label="Fast Forward">
-            <i className="material-icons">fast_forward</i></button>;
+            <FastForwardIcon size={48} /></button>;
 
         return <div className="columns is-mobile">
             <div className="column has-text-centered">

--- a/src/components/menu/ColorSchemeToggle.tsx
+++ b/src/components/menu/ColorSchemeToggle.tsx
@@ -1,13 +1,21 @@
 import * as React from 'react';
 import {WithTranslation, withTranslation} from "react-i18next";
+import BrightnessAutoIcon from "mdi-react/BrightnessAutoIcon";
+import Brightness4Icon from "mdi-react/Brightness4Icon";
+import Brightness5Icon from "mdi-react/Brightness5Icon";
 import {ColorScheme} from "../../constants/ColorScheme";
 import ColorSchemeHelpers from "../../util/ColorSchemeHelpers";
-
 
 interface IProps extends WithTranslation {
     activeColorScheme: ColorScheme
     onToggleColorScheme?: (colorScheme: ColorScheme) => void;
 }
+
+const brightnessIcons = {
+    [ColorScheme.AUTO]: <BrightnessAutoIcon />,
+    [ColorScheme.DARK]: <Brightness4Icon />,
+    [ColorScheme.LIGHT]: <Brightness5Icon />,
+};
 
 class ColorSchemeToggle extends React.Component<IProps, object> {
     constructor(props: IProps) {
@@ -53,11 +61,7 @@ class ColorSchemeToggle extends React.Component<IProps, object> {
             }
         };
 
-        const iconLigature: string = {
-            [ColorScheme.AUTO]: 'brightness_auto',
-            [ColorScheme.DARK]: 'brightness_4',
-            [ColorScheme.LIGHT]: 'brightness_5',
-        }[this.props.activeColorScheme];
+        const icon = brightnessIcons[this.props.activeColorScheme];
 
         return (
             <button className="button is-light has-tooltip-bottom has-tooltip-arrow"
@@ -66,7 +70,7 @@ class ColorSchemeToggle extends React.Component<IProps, object> {
                     data-tooltip={this.props.t('navbar.toggleColorScheme', {
                         'scheme': this.props.t('navbar.colorScheme.'+ this.props.activeColorScheme)
                     })}>
-                <i className="material-icons">{iconLigature}</i>
+                {icon}
             </button>
         );
     }

--- a/src/components/menu/Modal.tsx
+++ b/src/components/menu/Modal.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 import {Trans, WithTranslation, withTranslation} from "react-i18next";
+import LoopIcon from "mdi-react/LoopIcon";
 import NameGenerator from "../../util/NameGenerator";
 import Player from "../../constants/Player";
 
@@ -37,7 +38,7 @@ class Modal extends React.Component<IProps, object> {
                                                 onClick={this.newNameProposal}
                                                 aria-label={this.props.t('modal.randomizeName')}
                                                 data-tooltip={this.props.t('modal.randomizeName')}>
-                                            <i className='material-icons'>loop</i>
+                                            <LoopIcon />
                                         </button>
                                     </div>
                                 </div>

--- a/src/sass/bulma.scss
+++ b/src/sass/bulma.scss
@@ -33,7 +33,6 @@ $family-monospace: 'SF Mono', 'Consolas', 'Monaco', monospace;
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
 @import url('https://fonts.googleapis.com/css2?family=Crete+Round:ital@0;1&display=swap');
-@import url('https://fonts.googleapis.com/icon?family=Material+Icons');
 
 .content h1, .content h2, .content h3, .content h4, .content h5, .content h6, .navbar-brand h1 {
   font-family: 'Crete Round', sans-serif;
@@ -442,10 +441,6 @@ div.stretchy-wrapper > div.stretchy-text {
   padding: 0;
 }
 
-.spectator-action .material-icons {
-  font-size: 48px;
-}
-
 #countdown-timer {
   display: inline-block;
   font-weight: 600;
@@ -537,10 +532,6 @@ div.stretchy-wrapper > div.stretchy-text {
   height: 48px;
   color: $scheme-invert !important;
   opacity: 0.60;
-}
-
-.back-icon.header-navigation .material-icons {
-  font-size: 48px;
 }
 
 .back-icon.header-navigation:hover {


### PR DESCRIPTION
mdi-react has all the material design icons as SVG rather than font ligatures. Saves some network requests too, probably, so hopefully this is both faster and more reliable :pray: 