### PR TITLE
Set cache headers for static assets

### DIFF
--- a/src/DraftServer.ts
+++ b/src/DraftServer.ts
@@ -98,7 +98,17 @@ export const DraftServer = {
             }
         });
 
-        app.use(express.static('build'));
+        app.use(express.static('build', {
+            etag: true,
+            lastModified: true,
+            setHeaders: (res, path) => {
+                if (path.startsWith(__dirname + '/static') || path.startsWith(__dirname + '/images')) {
+                    res.setHeader('Cache-Control', 'public, max-age=864000');
+                } else {
+                    res.setHeader('Cache-Control', 'no-cache');
+                }
+            },
+        }));
         app.use('/', (req, res) => {
             if (fs.existsSync(indexPath)) {
                 res.sendFile(indexPath);

--- a/src/DraftServer.ts
+++ b/src/DraftServer.ts
@@ -104,8 +104,6 @@ export const DraftServer = {
             setHeaders: (res, path) => {
                 if (path.startsWith(__dirname + '/static') || path.startsWith(__dirname + '/images')) {
                     res.setHeader('Cache-Control', 'public, max-age=864000');
-                } else {
-                    res.setHeader('Cache-Control', 'no-cache');
                 }
             },
         }));


### PR DESCRIPTION
Set `Cache-Control=public, max-age=864000` for `/images` and `/static/css` and `/static/js`.

Fixes #53 