### PR TITLE
Improve the contrast of tags in dark mode

### DIFF
--- a/src/sass/bulma-dark-tags.sass
+++ b/src/sass/bulma-dark-tags.sass
@@ -4,12 +4,12 @@
     $color: nth($pair, 1)
     $color-invert: nth($pair, 2)
     &.is-#{$name}
-      background-color: $color
+      background-color: darken($color, 20)
       color: $color-invert
       // If a light and dark colors are provided
       @if length($pair) > 3
         $color-light: nth($pair, 3)
         $color-dark: nth($pair, 4)
         &.is-light
-          background-color: $color-light
-          color: $color-dark
+          background-color: darken($color-dark, 15)
+          color: $color-light


### PR DESCRIPTION
### Summary
Improve the contrast of tags in dark mode

### Screenshots

Before
![before](https://user-images.githubusercontent.com/13775/94356562-ac994480-00ad-11eb-8356-c615e5253e51.png)

After
![after](https://user-images.githubusercontent.com/13775/94356568-b4f17f80-00ad-11eb-9cbf-35d0b0c01469.png)