### PR TITLE
Set the background color of the page for dark mode.

### DIFF
--- a/src/sass/bulma.scss
+++ b/src/sass/bulma.scss
@@ -710,7 +710,7 @@ div.stretchy-wrapper > div.stretchy-text {
 html.has-theme-dark {
   background-color: $black;
   body.has-theme-dark {
-    background-color: $black;
+    background-color: $black-bis;
     color: $grey;
   }
 }

--- a/src/sass/bulma.scss
+++ b/src/sass/bulma.scss
@@ -708,8 +708,9 @@ div.stretchy-wrapper > div.stretchy-text {
 
 // Dark Mode
 html.has-theme-dark {
+  background-color: $black;
   body.has-theme-dark {
-    background-color: $black-bis;
+    background-color: $black;
     color: $grey;
   }
 }


### PR DESCRIPTION
On high resolution monitors where the height of the page was less than the height of the viewport, part of the background appeared white / gray even in dark mode. This PR fixes that.