### PR TITLE
Spruce up the UI for /api page

### DIFF
--- a/src/components/menu/API.tsx
+++ b/src/components/menu/API.tsx
@@ -7,7 +7,7 @@ class API extends React.Component<object, object> {
         return (
             <div>
                 <div className="content box" id="API">
-                    <h3>API documentation</h3>
+                    <h3>API Documentation</h3>
                     <h4>Presets</h4>
                         <h5>Get Preset</h5>
                         <p>Request the selected preset.</p>

--- a/src/components/menu/API.tsx
+++ b/src/components/menu/API.tsx
@@ -8,130 +8,161 @@ class API extends React.Component<object, object> {
             <div>
                 <div className="content box" id="API">
                     <h3>API documentation</h3>
-                    <h4>Preset</h4>
-                    <h5>Get Preset</h5>
-                    <p>Request the selected preset.</p>
-                    <dl>
-                        <dt>Endpoint</dt>
-                        <dd>GET <code>/api/preset/:id</code></dd>
-                        <dt>Example URL</dt>
-                        <dd>https://aoe2cm.net/api/preset/simple</dd>
-                    </dl>
+                    {/*<details>*/}
+                        {/*<summary><hr/<h4>Preset</h4></summary>*/}
+                        <h4>Presets</h4>
+                        <h5>Get Preset</h5>
+                        <p>Request the selected preset.</p>
+                        <dl>
+                            <dt>Endpoint</dt>
+                            <dd><pre>GET /api/preset/:id</pre></dd>
+                            <dt>Example URL</dt>
+                            <dd><pre>https://aoe2cm.net/api/preset/simple</pre></dd>
+                            <dt>Response</dt>
+                            <dd><pre>A JSON encoded valid <a
+                                href={'https://github.com/SiegeEngineers/aoe2cm2/blob/master/src/models/Preset.ts'}>Preset</a> object.</pre>
+                            </dd>
+                        </dl>
 
-                    <h5>Add Preset</h5>
-                    <p>Create a new preset.</p>
-                    <dl>
-                        <dt>Endpoint</dt>
-                        <dd>POST <code>/api/preset/new</code></dd>
-                        <dt>Payload</dt>
-                        <dd>A JSON encoded valid <a
-                            href={'https://github.com/SiegeEngineers/aoe2cm2/blob/master/src/models/Preset.ts'}>Preset</a> object.
-                        </dd>
-                        <dt>Example URL</dt>
-                        <dd>https://aoe2cm.net/api/preset/new</dd>
-                        <dt>Example Response</dt>
-                        <dd><code>{'{"status": "ok", "presetId": "abcdef"}'}</code></dd>
-                    </dl>
+                        <h5>Add Preset</h5>
+                        <p>Create a new preset.</p>
+                        <dl>
+                            <dt>Endpoint</dt>
+                            <dd><pre>POST /api/preset/new</pre></dd>
+                            <dt>Payload</dt>
+                            <dd><pre>A JSON encoded valid <a
+                                href={'https://github.com/SiegeEngineers/aoe2cm2/blob/master/src/models/Preset.ts'}>Preset</a> object.</pre>
+                            </dd>
+                            <dt>Example URL</dt>
+                            <dd><pre>https://aoe2cm.net/api/preset/new</pre></dd>
+                            <dt>Example Response</dt>
+                            <dd><pre>{
+`{
+    "status": "ok", 
+    "presetId": "abCdE"
+}`
+                            }</pre></dd>
+                        </dl>
 
-                    <h5>List Presets</h5>
-                    <p>List ID and name of publicly listed presets.</p>
-                    <dl>
-                        <dt>Endpoint</dt>
-                        <dd>GET <code>/api/preset/list</code></dd>
-                        <dt>Example URL</dt>
-                        <dd>https://aoe2cm.net/api/preset/list</dd>
-                        <dt>Example Response</dt>
-                        <dd><code>{'[\
-                            {\
-                                "name": "Simple Preset",\
-                                "id": "simple"\
-                            },\
-                            {\
-                                "id": "Hidden_1v1",\
-                                "name": "Hidden 1v1"\
-                            }\
-                            ]'}</code></dd>
-                    </dl>
-
-                    <h4>Draft</h4>
+                        <h5>List Presets</h5>
+                        <p>List ID and name of publicly listed presets.</p>
+                        <dl>
+                            <dt>Endpoint</dt>
+                            <dd><pre>GET /api/preset/list</pre></dd>
+                            <dt>Example URL</dt>
+                            <dd><pre>https://aoe2cm.net/api/preset/list</pre></dd>
+                            <dt>Example Response</dt>
+                            <dd><pre>{
+`[
+    {
+        "name": "Simple Preset",
+        "id": "simple"
+    },
+    {
+        "id": "Hidden_1v1",
+        "name": "Hidden 1v1"
+    }
+]`
+                            }</pre></dd>
+                        </dl>
+                    {/*</details>*/}
+                    <hr/><h4>Drafts</h4>
                     <h5>Get Draft</h5>
                     <p>Get the data of a finished draft.</p>
                     <dl>
                         <dt>Endpoint</dt>
-                        <dd>GET <code>/api/draft/:id</code></dd>
+                        <dd><pre>GET /api/draft/:id</pre></dd>
                         <dt>Example URL</dt>
-                        <dd>https://aoe2cm.net/api/draft/FQoju</dd>
+                        <dd><pre>https://aoe2cm.net/api/draft/FQoju</pre></dd>
                         <dt>Response</dt>
-                        <dd>A JSON encoded <a
+                        <dd>
+                            <pre>A JSON encoded <a
                             href={'https://github.com/SiegeEngineers/aoe2cm2/blob/master/src/models/Draft.ts'}>Draft</a> object.
+                            </pre>
                         </dd>
                     </dl>
                     <h5>Create draft</h5>
                     <p>Create a new draft based on a preset.</p>
                     <dl>
                         <dt>Endpoint</dt>
-                        <dd>POST <code>/api/draft/new</code></dd>
+                        <dd><pre>POST /api/draft/new</pre></dd>
                         <dt>Payload</dt>
-                        <dd>A JSON encoded valid <a
+                        <dd><pre>A JSON encoded valid <a
                             href={'https://github.com/SiegeEngineers/aoe2cm2/blob/master/src/models/Preset.ts'}>Preset</a> object.
+                        </pre>
                         </dd>
                         <dt>Example URL</dt>
-                        <dd>https://aoe2cm.net/api/draft/new</dd>
+                        <dd><pre>https://aoe2cm.net/api/draft/new</pre></dd>
                         <dt>Example Response</dt>
-                        <dd><code>{'{"status": "ok", "draftId": "abcdef"}'}</code></dd>
+                        <dd><pre>{
+`{
+    "status": "ok", 
+    "draftId": "abCdE"
+}`
+                        }</pre></dd>
                     </dl>
 
                     <h5>List recent Drafts</h5>
-                    <p>Get a list of recent Drafts with title, draftId, ongoing, nameHost, and nameGuest for each of the
+                    <p>Get a list of recent Drafts with <code>title</code>, <code>draftId</code>, <code>ongoing</code>, <code>nameHost</code>, and <code>nameGuest</code> for each of the
                         drafts.</p>
                     <dl>
                         <dt>Endpoint</dt>
-                        <dd>GET <code>/api/recentdrafts</code></dd>
+                        <dd><pre>GET /api/recentdrafts</pre></dd>
                         <dt>Example URL</dt>
-                        <dd>https://aoe2cm.net/api/recentdrafts</dd>
+                        <dd><pre>https://aoe2cm.net/api/recentdrafts</pre></dd>
                         <dt>Example Response</dt>
-                        <dd><code>{'[{\
-                            "title": "Simple 1v1",\
-                            "draftId": "abcdef",\
-                            "ongoing": true,\
-                            "nameHost": "Macbeth",\
-                            "nameGuest": "General Kyebaek"\
-                        },{\
-                            "title": "Hidden 3v3",\
-                            "draftId": "fghij",\
-                            "ongoing": false,\
-                            "nameHost": "Wenceslaus I",\
-                            "nameGuest": "Pepin the Short"\
-                        }]'}</code></dd>
+                        <dd><pre>{
+`[
+    {
+        "title": "Simple 1v1",
+        "draftId": "abcdef",
+        "ongoing": true,
+        "nameHost": "Macbeth",
+        "nameGuest": "General Kyebaek"
+    },{
+        "title": "Hidden 3v3",
+        "draftId": "fghij",
+        "ongoing": false,
+        "nameHost": "Wenceslaus I",
+        "nameGuest": "Pepin the Short"
+    }
+]`
+                        }</pre></dd>
                     </dl>
 
 
-                    <h4>Open Connections</h4>
+                    <hr/><h4>Open Connections</h4>
                     <p>Show the number of current connections.</p>
                     <dl>
                         <dt>Endpoint</dt>
-                        <dd>GET <code>/api/connections</code></dd>
+                        <dd><pre>GET /api/connections</pre></dd>
                         <dt>Example URL</dt>
-                        <dd>https://aoe2cm.net/api/connections</dd>
+                        <dd><pre>https://aoe2cm.net/api/connections</pre></dd>
                         <dt>Example Response</dt>
-                        <dd><code>{'{"connections":6}'}</code></dd>
+                        <dd><pre>{
+`{
+    "connections":6
+}`
+                        }</pre></dd>
                     </dl>
 
-                    <h4>Alerts</h4>
+                    <hr/><h4>Alerts</h4>
                     <p>List alerts that are displayed on the main page.</p>
                     <dl>
                         <dt>Endpoint</dt>
-                        <dd>GET <code>/api/alerts</code></dd>
+                        <dd><pre>GET /api/alerts</pre></dd>
                         <dt>Example URL</dt>
-                        <dd>https://aoe2cm.net/api/alerts</dd>
+                        <dd><pre>https://aoe2cm.net/api/alerts</pre></dd>
                         <dt>Example Response</dt>
-                        <dd><code>{'[\
-                            {\
-                                "class": "info",\
-                                "title": "Sample Alert",\
-                                "content": "<b>This is a sample!</b> Great, isn\'t it?"\
-                            }\
-                            ]'}</code></dd>
+                        <dd><pre>{
+`[
+    {
+        "class": "info",
+        "title": "Sample Alert",
+        "content": "<b>This is a sample!</b> Great, isn\'t it?"
+    }
+]`
+                        }</pre></dd>
                     </dl>
                 </div>
             </div>

--- a/src/components/menu/API.tsx
+++ b/src/components/menu/API.tsx
@@ -102,14 +102,14 @@ class API extends React.Component<object, object> {
 `[
     {
         "title": "Simple 1v1",
-        "draftId": "abcdef",
+        "draftId": "abCDe",
         "ongoing": true,
         "nameHost": "Macbeth",
         "nameGuest": "General Kyebaek"
     },
     {
         "title": "Hidden 3v3",
-        "draftId": "fghij",
+        "draftId": "FGhIj",
         "ongoing": false,
         "nameHost": "Wenceslaus I",
         "nameGuest": "Pepin the Short"

--- a/src/components/menu/API.tsx
+++ b/src/components/menu/API.tsx
@@ -8,16 +8,12 @@ class API extends React.Component<object, object> {
             <div>
                 <div className="content box" id="API">
                     <h3>API documentation</h3>
-                    {/*<details>*/}
-                        {/*<summary><hr/<h4>Preset</h4></summary>*/}
-                        <h4>Presets</h4>
+                    <h4>Presets</h4>
                         <h5>Get Preset</h5>
                         <p>Request the selected preset.</p>
                         <dl>
                             <dt>Endpoint</dt>
-                            <dd><pre>GET /api/preset/:id</pre></dd>
-                            <dt>Example URL</dt>
-                            <dd><pre>https://aoe2cm.net/api/preset/simple</pre></dd>
+                            <dd><pre>GET https://aoe2cm.net/api/preset/:id</pre></dd>
                             <dt>Response</dt>
                             <dd><pre>A JSON encoded valid <a
                                 href={'https://github.com/SiegeEngineers/aoe2cm2/blob/master/src/models/Preset.ts'}>Preset</a> object.</pre>
@@ -28,14 +24,12 @@ class API extends React.Component<object, object> {
                         <p>Create a new preset.</p>
                         <dl>
                             <dt>Endpoint</dt>
-                            <dd><pre>POST /api/preset/new</pre></dd>
+                            <dd><pre>POST https://aoe2cm.net/api/preset/new</pre></dd>
                             <dt>Payload</dt>
                             <dd><pre>A JSON encoded valid <a
                                 href={'https://github.com/SiegeEngineers/aoe2cm2/blob/master/src/models/Preset.ts'}>Preset</a> object.</pre>
                             </dd>
-                            <dt>Example URL</dt>
-                            <dd><pre>https://aoe2cm.net/api/preset/new</pre></dd>
-                            <dt>Example Response</dt>
+                            <dt>Sample Response</dt>
                             <dd><pre>{
 `{
     "status": "ok", 
@@ -48,10 +42,8 @@ class API extends React.Component<object, object> {
                         <p>List ID and name of publicly listed presets.</p>
                         <dl>
                             <dt>Endpoint</dt>
-                            <dd><pre>GET /api/preset/list</pre></dd>
-                            <dt>Example URL</dt>
-                            <dd><pre>https://aoe2cm.net/api/preset/list</pre></dd>
-                            <dt>Example Response</dt>
+                            <dd><pre>GET https://aoe2cm.net/api/preset/list</pre></dd>
+                            <dt>Sample Response</dt>
                             <dd><pre>{
 `[
     {
@@ -65,15 +57,15 @@ class API extends React.Component<object, object> {
 ]`
                             }</pre></dd>
                         </dl>
-                    {/*</details>*/}
-                    <hr/><h4>Drafts</h4>
+
+                    <hr/>
+
+                    <h4>Drafts</h4>
                     <h5>Get Draft</h5>
                     <p>Get the data of a finished draft.</p>
                     <dl>
                         <dt>Endpoint</dt>
-                        <dd><pre>GET /api/draft/:id</pre></dd>
-                        <dt>Example URL</dt>
-                        <dd><pre>https://aoe2cm.net/api/draft/FQoju</pre></dd>
+                        <dd><pre>GET https://aoe2cm.net/api/draft/:id</pre></dd>
                         <dt>Response</dt>
                         <dd>
                             <pre>A JSON encoded <a
@@ -85,15 +77,13 @@ class API extends React.Component<object, object> {
                     <p>Create a new draft based on a preset.</p>
                     <dl>
                         <dt>Endpoint</dt>
-                        <dd><pre>POST /api/draft/new</pre></dd>
+                        <dd><pre>POST https://aoe2cm.net/api/draft/new</pre></dd>
                         <dt>Payload</dt>
                         <dd><pre>A JSON encoded valid <a
                             href={'https://github.com/SiegeEngineers/aoe2cm2/blob/master/src/models/Preset.ts'}>Preset</a> object.
                         </pre>
                         </dd>
-                        <dt>Example URL</dt>
-                        <dd><pre>https://aoe2cm.net/api/draft/new</pre></dd>
-                        <dt>Example Response</dt>
+                        <dt>Sample Response</dt>
                         <dd><pre>{
 `{
     "status": "ok", 
@@ -103,14 +93,11 @@ class API extends React.Component<object, object> {
                     </dl>
 
                     <h5>List recent Drafts</h5>
-                    <p>Get a list of recent Drafts with <code>title</code>, <code>draftId</code>, <code>ongoing</code>, <code>nameHost</code>, and <code>nameGuest</code> for each of the
-                        drafts.</p>
+                    <p>Get a list of 10 most recent Drafts.</p>
                     <dl>
                         <dt>Endpoint</dt>
-                        <dd><pre>GET /api/recentdrafts</pre></dd>
-                        <dt>Example URL</dt>
-                        <dd><pre>https://aoe2cm.net/api/recentdrafts</pre></dd>
-                        <dt>Example Response</dt>
+                        <dd><pre>GET https://aoe2cm.net/api/recentdrafts</pre></dd>
+                        <dt>Sample Response</dt>
                         <dd><pre>{
 `[
     {
@@ -131,14 +118,14 @@ class API extends React.Component<object, object> {
                     </dl>
 
 
-                    <hr/><h4>Open Connections</h4>
+                    <hr/>
+
+                    <h4>Open Connections</h4>
                     <p>Show the number of current connections.</p>
                     <dl>
                         <dt>Endpoint</dt>
-                        <dd><pre>GET /api/connections</pre></dd>
-                        <dt>Example URL</dt>
-                        <dd><pre>https://aoe2cm.net/api/connections</pre></dd>
-                        <dt>Example Response</dt>
+                        <dd><pre>GET https://aoe2cm.net/api/connections</pre></dd>
+                        <dt>Sample Response</dt>
                         <dd><pre>{
 `{
     "connections":6
@@ -146,14 +133,14 @@ class API extends React.Component<object, object> {
                         }</pre></dd>
                     </dl>
 
-                    <hr/><h4>Alerts</h4>
+                    <hr/>
+
+                    <h4>Alerts</h4>
                     <p>List alerts that are displayed on the main page.</p>
                     <dl>
                         <dt>Endpoint</dt>
-                        <dd><pre>GET /api/alerts</pre></dd>
-                        <dt>Example URL</dt>
-                        <dd><pre>https://aoe2cm.net/api/alerts</pre></dd>
-                        <dt>Example Response</dt>
+                        <dd><pre>GET https://aoe2cm.net/api/alerts</pre></dd>
+                        <dt>Sample Response</dt>
                         <dd><pre>{
 `[
     {

--- a/src/components/menu/API.tsx
+++ b/src/components/menu/API.tsx
@@ -106,7 +106,8 @@ class API extends React.Component<object, object> {
         "ongoing": true,
         "nameHost": "Macbeth",
         "nameGuest": "General Kyebaek"
-    },{
+    },
+    {
         "title": "Hidden 3v3",
         "draftId": "fghij",
         "ongoing": false,
@@ -128,7 +129,7 @@ class API extends React.Component<object, object> {
                         <dt>Sample Response</dt>
                         <dd><pre>{
 `{
-    "connections":6
+    "connections": 6
 }`
                         }</pre></dd>
                     </dl>
@@ -146,7 +147,8 @@ class API extends React.Component<object, object> {
     {
         "class": "info",
         "title": "Sample Alert",
-        "content": "<b>This is a sample!</b> Great, isn\'t it?"
+        "content": "<b>This is a sample!</b> Great, isn\'t it?",
+        "closable": false
     }
 ]`
                         }</pre></dd>

--- a/src/components/menu/API.tsx
+++ b/src/components/menu/API.tsx
@@ -39,7 +39,7 @@ class API extends React.Component<object, object> {
                         </dl>
 
                         <h5>List Presets</h5>
-                        <p>List ID and name of publicly listed presets.</p>
+                        <p>Get a list of publicly listed presets.</p>
                         <dl>
                             <dt>Endpoint</dt>
                             <dd><pre>GET https://aoe2cm.net/api/preset/list</pre></dd>
@@ -47,8 +47,8 @@ class API extends React.Component<object, object> {
                             <dd><pre>{
 `[
     {
-        "name": "Simple Preset",
         "id": "simple"
+        "name": "Simple Preset",
     },
     {
         "id": "Hidden_1v1",

--- a/src/sass/bulma-dark.scss
+++ b/src/sass/bulma-dark.scss
@@ -115,9 +115,15 @@ label.civ-select:hover {
   border-right: .5rem solid $grey;
 }
 
-code {
+code, pre {
   color: inherit;
   border-radius: 4px;
+  background-color: $black-bis;
+}
+
+hr {
+  background-color: $grey-dark;
+  border-color: $grey-dark;
 }
 
 .box {

--- a/src/sass/bulma.scss
+++ b/src/sass/bulma.scss
@@ -28,7 +28,7 @@ $ban-red: #cc3333;
 $steal-gold: #ffc107;
 $host-cyan: #00bcd4;
 $guest-gold: #ffc107;
-$family-monospace: 'SF Mono', 'Consolas', 'Monaco', monospace;
+$family-monospace: 'Consolas', 'Monaco', monospace;
 
 @import "../../node_modules/bulma/bulma.sass";
 
@@ -38,6 +38,11 @@ $family-monospace: 'SF Mono', 'Consolas', 'Monaco', monospace;
 .content h1, .content h2, .content h3, .content h4, .content h5, .content h6, .navbar-brand h1 {
   font-family: 'Crete Round', sans-serif;
   font-weight: 300;
+}
+.content {
+  h5, h6 {
+    color: $grey;
+  }
 }
 
 body, .box, .column, .tag, .table, td, .button, .bar, .navbar, .footer, .input, .message, a, code, .tabs ul {


### PR DESCRIPTION
### Summary
Spruce up the UI for `/api` page

### Changes

- Merge Endpoint and Sample URL
- Use `<pre>` tags to format responses
- Use color to differentiate H5 and H6 from other heading