### PR TITLE
Simplified UI for Streamers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3738,9 +3738,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001112",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001112.tgz",
-      "integrity": "sha512-J05RTQlqsatidif/38aN3PGULCLrg8OYQOlJUKbeYVzC2mGZkZLIztwRlB3MtrfLmawUmjFlNJvy/uhwniIe1Q=="
+      "version": "1.0.30001200",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001200.tgz",
+      "integrity": "sha512-ic/jXfa6tgiPBAISWk16jRI2q8YfjxHnSG7ddSL1ptrIP8Uy11SayFrjXRAk3NumHpDb21fdTkbTxb/hOrFrnQ=="
     },
     "capture-exit": {
       "version": "2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3607,6 +3607,11 @@
       "integrity": "sha512-EeDW8pQrkYEOXo2l3WykfghbUzi8jlQWGI+Cu2HwmXwQHMcoGF6yiKYCNShttN+8z3atq8fLWh3B7pqXUV4fBA==",
       "dev": true
     },
+    "bulma-switch": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/bulma-switch/-/bulma-switch-2.0.0.tgz",
+      "integrity": "sha512-myD38zeUfjmdduq+pXabhJEe3x2hQP48l/OI+Y0fO3HdDynZUY/VJygucvEAJKRjr4HxD5DnEm4yx+oDOBXpAA=="
+    },
     "bytes": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "@types/socket.io": "^2.1.10",
     "@types/socket.io-client": "^1.4.33",
     "@types/uuid": "^8.0.1",
+    "bulma-switch": "^2.0.0",
     "express": "^4.17.1",
     "i18next": "^19.6.3",
     "i18next-browser-languagedetector": "^5.0.1",

--- a/src/components/draft/Draft.tsx
+++ b/src/components/draft/Draft.tsx
@@ -205,28 +205,34 @@ class Draft extends React.Component<IProps, IState> {
             </section>
 
             <section className="section pt-0">
-                <div className="container is-desktop has-text-centered mb-3" style={{maxWidth: "808px"}}>
-                    <div className="buttons is-centered">
-                        <button className={'button is-small'} onClick={() => {
-                            this.flip()
-                        }}>
-                            <Trans i18nKey='flip'>Flip Host and Guest positions</Trans>
-                        </button>
-                        <button className={'button is-small'} onClick={() => {
-                            this.toggleSmooch()
-                        }}>
-                            <Trans i18nKey='smooch'>Toggle smooch mode</Trans>
-                        </button>
-                        <button className={'button is-small'} onClick={() => {
-                            this.toggleSimplifiedUI()
-                        }}>
-                            <Trans i18nKey='simplifiedUI'>Toggle Simplified UI</Trans>
-                        </button>
+                <div className="container is-mobile has-text-centered">
+                    <div className="field is-grouped is-grouped-centered">
+                        <p className="control">
+                            <input id="toggleFlip" type="checkbox" name="toggleSmooch"
+                                   className="switch is-small is-rounded is-info" checked={this.state.flipped} onClick={() => {
+                                this.flip()
+                            }}/>
+                            <label htmlFor="toggleFlip" className={"is-size-7"} style={{paddingTop:1}}><Trans i18nKey='flip'>Flip Host and Guest positions</Trans></label>
+                        </p>
+                        <p className="control">
+                            <input id="toggleSmooch" type="checkbox" name="toggleSmooch"
+                                   className="switch is-small is-rounded is-info" checked={this.state.smooch} onClick={() => {
+                                this.toggleSmooch()
+                            }}/>
+                            <label htmlFor="toggleSmooch" className={"is-size-7"} style={{paddingTop:1}}><Trans i18nKey='smooch'>Smooch Mode</Trans></label>
+                        </p>
+                        <p className="control">
+                            <input id="toggleSimplifiedUI" type="checkbox" name="toggleSimplifiedUI"
+                                   className="switch is-small is-rounded is-info" checked={this.state.simplifiedUI} onClick={() => {
+                                this.toggleSimplifiedUI()
+                            }}/>
+                            <label htmlFor="toggleSimplifiedUI" className={"is-size-7"} style={{paddingTop:1}}><Trans i18nKey='simplifiedUI'>Simplified UI</Trans></label>
+                        </p>
                     </div>
                 </div>
             </section>
 
-            <section className="section pt-0">
+            {!this.state.simplifiedUI && <section className="section pt-0">
                 <div className="container is-desktop has-text-centered" style={{maxWidth: "808px"}}>
                     <details>
                         <summary className="has-cursor-pointer"><Trans i18nKey='menu.howItWorks'>How it works</Trans></summary>
@@ -234,11 +240,11 @@ class Draft extends React.Component<IProps, IState> {
                     </details>
                 </div>
             </section>
+            }
 
             </>
         );
     }
-
 }
 
 export default withTranslation()(withRouter(Draft));

--- a/src/components/draft/Draft.tsx
+++ b/src/components/draft/Draft.tsx
@@ -108,7 +108,7 @@ class Draft extends React.Component<IProps, IState> {
         if (this.props.triggerDisconnect) {
             this.props.triggerDisconnect();
         }
-        ColorSchemeHelpers.removeThemeClassName('has-theme-simple-ui')
+        ColorSchemeHelpers.removeThemeClassName('has-simple-ui')
         if (this.props.history.length > 2 && document.referrer) {
             // go back if there is a possibility
             this.props.history.goBack();
@@ -152,7 +152,7 @@ class Draft extends React.Component<IProps, IState> {
     public render() {
         let presetName: JSX.Element = <>{this.props.preset.name}</>;
         if(this.props.preset.presetId){
-            presetName = <Link to={'/preset/'+this.props.preset.presetId}>{presetName}</Link>
+            presetName = <Link to={'/preset/'+this.props.preset.presetId}>{presetName}</Link>;
         }
         const turns = this.props.preset.turns;
 
@@ -161,9 +161,9 @@ class Draft extends React.Component<IProps, IState> {
         className += this.state.smooch ? ' smooch' : '';
 
         if(this.state.simplifiedUI) {
-            ColorSchemeHelpers.addThemeClassName('has-theme-simple-ui')
+            ColorSchemeHelpers.addThemeClassName('has-simple-ui');
         } else {
-            ColorSchemeHelpers.removeThemeClassName('has-theme-simple-ui')
+            ColorSchemeHelpers.removeThemeClassName('has-simple-ui');
         }
 
         return (
@@ -212,21 +212,21 @@ class Draft extends React.Component<IProps, IState> {
                                    className="switch is-small is-rounded is-info" checked={this.state.flipped} onClick={() => {
                                 this.flip()
                             }}/>
-                            <label htmlFor="toggleFlip" className={"is-size-7"} style={{paddingTop:1}}><Trans i18nKey='flip'>Flip Host and Guest positions</Trans></label>
+                            <label htmlFor="toggleFlip" style={{paddingTop:1}}><Trans i18nKey='flip'>Flip Host and Guest positions</Trans></label>
                         </p>
                         <p className="control">
                             <input id="toggleSmooch" type="checkbox" name="toggleSmooch"
                                    className="switch is-small is-rounded is-info" checked={this.state.smooch} onClick={() => {
                                 this.toggleSmooch()
                             }}/>
-                            <label htmlFor="toggleSmooch" className={"is-size-7"} style={{paddingTop:1}}><Trans i18nKey='smooch'>Smooch Mode</Trans></label>
+                            <label htmlFor="toggleSmooch" style={{paddingTop:1}}><Trans i18nKey='smooch'>Smooch Mode</Trans></label>
                         </p>
                         <p className="control">
                             <input id="toggleSimplifiedUI" type="checkbox" name="toggleSimplifiedUI"
                                    className="switch is-small is-rounded is-info" checked={this.state.simplifiedUI} onClick={() => {
                                 this.toggleSimplifiedUI()
                             }}/>
-                            <label htmlFor="toggleSimplifiedUI" className={"is-size-7"} style={{paddingTop:1}}><Trans i18nKey='simplifiedUI'>Simplified UI</Trans></label>
+                            <label htmlFor="toggleSimplifiedUI" style={{paddingTop:1}}><Trans i18nKey='simplifiedUI'>Simplified UI</Trans></label>
                         </p>
                     </div>
                 </div>

--- a/src/components/draft/Draft.tsx
+++ b/src/components/draft/Draft.tsx
@@ -220,7 +220,7 @@ class Draft extends React.Component<IProps, IState> {
                         <button className={'button is-small'} onClick={() => {
                             this.toggleSimplifiedUI()
                         }}>
-                            <Trans i18nKey='simplifiedUIAdd'>Toggle Simplified UI</Trans>
+                            <Trans i18nKey='simplifiedUI'>Toggle Simplified UI</Trans>
                         </button>
                     </div>
                 </div>

--- a/src/components/draft/Draft.tsx
+++ b/src/components/draft/Draft.tsx
@@ -20,6 +20,7 @@ import {default as ModelAction} from "../../constants/Action";
 import ReplayControls from "../../containers/ReplayControls";
 import {RouteComponentProps} from "react-router";
 import HowItWorks from "../menu/HowItWorks";
+import ColorSchemeHelpers from "../../util/ColorSchemeHelpers";
 
 interface IProps extends WithTranslation, RouteComponentProps<any> {
     nameHost: string;
@@ -52,6 +53,7 @@ interface IState {
     joined: boolean;
     flipped: boolean;
     smooch: boolean;
+    simplifiedUI: boolean;
 }
 
 class Draft extends React.Component<IProps, IState> {
@@ -61,7 +63,8 @@ class Draft extends React.Component<IProps, IState> {
         let query = new URLSearchParams(this.props.location.search);
         const flipped = query.get('flipped') === 'true' || false;
         const smooch = query.get('smooch') === 'true' || false;
-        this.state = {joined: false, flipped, smooch};
+        const simplifiedUI = query.get('simplified') === 'true' || false;
+        this.state = {joined: false, flipped, smooch, simplifiedUI};
     }
 
 
@@ -105,6 +108,7 @@ class Draft extends React.Component<IProps, IState> {
         if (this.props.triggerDisconnect) {
             this.props.triggerDisconnect();
         }
+        ColorSchemeHelpers.removeThemeClassName('has-theme-simple-ui')
         if (this.props.history.length > 2 && document.referrer) {
             // go back if there is a possibility
             this.props.history.goBack();
@@ -118,7 +122,7 @@ class Draft extends React.Component<IProps, IState> {
         const newFlippedValue = !this.state.flipped;
         let searchParams = new URLSearchParams(this.props.location.search);
         searchParams.set('flipped', newFlippedValue.toString());
-        this.props.history.push({
+        this.props.history.replace({
             search: searchParams.toString()
         });
         this.setState({...this.state, flipped: newFlippedValue});
@@ -128,10 +132,21 @@ class Draft extends React.Component<IProps, IState> {
         const newSmoochValue = !this.state.smooch;
         let searchParams = new URLSearchParams(this.props.location.search);
         searchParams.set('smooch', newSmoochValue.toString());
-        this.props.history.push({
+        this.props.history.replace({
             search: searchParams.toString()
         });
         this.setState({...this.state, smooch: newSmoochValue});
+    }
+
+    private toggleSimplifiedUI():void{
+        console.log('Simplified UI Toggle')
+        const newSimplifiedUIValue = !this.state.simplifiedUI;
+        let searchParams = new URLSearchParams(this.props.location.search);
+        searchParams.set('simplified', newSimplifiedUIValue.toString());
+        this.props.history.replace({
+            search: searchParams.toString()
+        });
+        this.setState({...this.state, simplifiedUI: newSimplifiedUIValue});
     }
 
     public render() {
@@ -144,6 +159,12 @@ class Draft extends React.Component<IProps, IState> {
         let className = 'section';
         className += this.state.flipped ? ' flipped' : '';
         className += this.state.smooch ? ' smooch' : '';
+
+        if(this.state.simplifiedUI) {
+            ColorSchemeHelpers.addThemeClassName('has-theme-simple-ui')
+        } else {
+            ColorSchemeHelpers.removeThemeClassName('has-theme-simple-ui')
+        }
 
         return (
             <>
@@ -166,7 +187,8 @@ class Draft extends React.Component<IProps, IState> {
                     <TurnRow turns={turns}/>
 
                     <DraftState nameHost={this.props.nameHost} nameGuest={this.props.nameGuest}
-                                preset={this.props.preset}/>
+                                preset={this.props.preset}
+                                simplifiedUI={this.state.simplifiedUI} />
 
                     <div className="columns is-mobile">
                         <div id="action-text" className="column has-text-centered is-size-4">
@@ -176,9 +198,31 @@ class Draft extends React.Component<IProps, IState> {
 
                     <ReplayControls/>
 
-                    <DraftIdInfo/>
+                    {!this.state.simplifiedUI && <DraftIdInfo/>}
 
-                    <CivGrid civilisations={this.props.preset.civilisations}/>
+                    {!this.state.simplifiedUI && <CivGrid civilisations={this.props.preset.civilisations}/>}
+                </div>
+            </section>
+
+            <section className="section pt-0">
+                <div className="container is-desktop has-text-centered mb-3" style={{maxWidth: "808px"}}>
+                    <div className="buttons is-centered">
+                        <button className={'button is-small'} onClick={() => {
+                            this.flip()
+                        }}>
+                            <Trans i18nKey='flip'>Flip Host and Guest positions</Trans>
+                        </button>
+                        <button className={'button is-small'} onClick={() => {
+                            this.toggleSmooch()
+                        }}>
+                            <Trans i18nKey='smooch'>Toggle smooch mode</Trans>
+                        </button>
+                        <button className={'button is-small'} onClick={() => {
+                            this.toggleSimplifiedUI()
+                        }}>
+                            <Trans i18nKey='simplifiedUIAdd'>Toggle Simplified UI</Trans>
+                        </button>
+                    </div>
                 </div>
             </section>
 
@@ -191,15 +235,7 @@ class Draft extends React.Component<IProps, IState> {
                 </div>
             </section>
 
-            <div className="container is-desktop has-text-centered mb-3" style={{maxWidth: "808px"}}>
-                <button className={'button is-small'} onClick={()=>{this.flip()}}>
-                    <Trans i18nKey='flip'>Flip Host and Guest positions</Trans>
-                </button>
-                <button className={'button is-small'} onClick={()=>{this.toggleSmooch()}}>
-                    <Trans i18nKey='smooch'>Toggle smooch mode</Trans>
-                </button>
-            </div>
-        </>
+            </>
         );
     }
 

--- a/src/components/draft/DraftState.tsx
+++ b/src/components/draft/DraftState.tsx
@@ -7,6 +7,7 @@ interface IProps {
     nameHost: string;
     nameGuest: string;
     preset: Preset;
+    simplifiedUI: boolean;
 }
 
 class DraftState extends React.Component<IProps, object> {
@@ -16,11 +17,13 @@ class DraftState extends React.Component<IProps, object> {
                 <PlayerDraftState preset={this.props.preset}
                                   player={ModelPlayer.HOST}
                                   name={this.props.nameHost}
-                                  key={ModelPlayer.HOST}/>
+                                  key={ModelPlayer.HOST}
+                                  simplifiedUI={this.props.simplifiedUI}/>
                 <PlayerDraftState preset={this.props.preset}
                                   player={ModelPlayer.GUEST}
                                   name={this.props.nameGuest}
-                                  key={ModelPlayer.GUEST}/>
+                                  key={ModelPlayer.GUEST}
+                                  simplifiedUI={this.props.simplifiedUI}/>
             </div>
         );
     }

--- a/src/components/draft/PlayerDraftState.tsx
+++ b/src/components/draft/PlayerDraftState.tsx
@@ -18,6 +18,7 @@ interface IProps extends WithTranslation {
     name: string;
     nextAction?: number;
     events?: DraftEvent[];
+    simplifiedUI?: boolean
 }
 
 interface IState {
@@ -121,22 +122,24 @@ class PlayerDraftState extends React.Component<IProps, IState> {
             <div id={playerId} className="column is-half">
                 <div className={playerClass + " box content is-inline-block"}>
                     <div className="is-uppercase has-text-grey is-size-7 pb-2 captains-line">
-                        <span className={'player-type'}><Trans>{this.props.player}</Trans></span>&nbsp;
-                        <WhoAmIIndicator forPlayer={this.props.player}/>&nbsp;
-                        <PlayerOnlineStatus forPlayer={this.props.player}/>
+                        {!this.props.simplifiedUI && <>
+                            <span className={'player-type'}><Trans>{this.props.player}</Trans></span>&nbsp;
+                            <WhoAmIIndicator forPlayer={this.props.player}/>&nbsp;
+                            <PlayerOnlineStatus forPlayer={this.props.player}/>
+                        </>}
                     </div>
                     <div className="player-head">
                         <h4 className="player-name">{this.props.name}</h4>
                     </div>
                     <div className="chosen">
                         {pickPanels.length > 0 && <>
-                            <div className="is-uppercase has-text-grey is-size-7 pb-2 sub-heading"><Trans>Picks</Trans></div>
+                            {!this.props.simplifiedUI && <div className="is-uppercase has-text-grey is-size-7 pb-2 sub-heading"><Trans>Picks</Trans></div>}
                             <div className="picks">
-                                {pickPanels}
+                                {pickPanels}{this.props.simplifiedUI && banPanels.length > 0 && banPanels}
                             </div>
                         </>}
-                        {banPanels.length > 0 && <>
-                            <div className="is-uppercase has-text-grey is-size-7 py-2 sub-heading"><Trans>Bans</Trans></div>
+                        {!this.props.simplifiedUI && banPanels.length > 0 && <>
+                            {!this.props.simplifiedUI && <div className="is-uppercase has-text-grey is-size-7 py-2 sub-heading"><Trans>Bans</Trans></div>}
                             <div className="bans">
                                 {banPanels}
                             </div>

--- a/src/components/draft/PlayerDraftState.tsx
+++ b/src/components/draft/PlayerDraftState.tsx
@@ -139,7 +139,7 @@ class PlayerDraftState extends React.Component<IProps, IState> {
                             </div>
                         </>}
                         {!this.props.simplifiedUI && banPanels.length > 0 && <>
-                            {!this.props.simplifiedUI && <div className="is-uppercase has-text-grey is-size-7 py-2 sub-heading"><Trans>Bans</Trans></div>}
+                            <div className="is-uppercase has-text-grey is-size-7 py-2 sub-heading"><Trans>Bans</Trans></div>
                             <div className="bans">
                                 {banPanels}
                             </div>

--- a/src/languages/en_GB.json
+++ b/src/languages/en_GB.json
@@ -126,8 +126,8 @@
   "<0></0>PICK": "<0></0>PICK",
   "<0></0>BAN": "<0></0>BAN",
   "flip": "Flip Host and Guest positions",
-  "smooch": "Toggle smooch mode",
-  "simplifiedUI": "Toggle Simplified UI",
+  "smooch": "Smooch mode",
+  "simplifiedUI": "Simplified UI",
   "validationFailed": "Validation(s) failed:",
   "errors": {
     "VLD_000": "Draft is currently not expecting actions",

--- a/src/languages/en_GB.json
+++ b/src/languages/en_GB.json
@@ -127,6 +127,7 @@
   "<0></0>BAN": "<0></0>BAN",
   "flip": "Flip Host and Guest positions",
   "smooch": "Toggle smooch mode",
+  "simplifiedUI": "Toggle Simplified UI",
   "validationFailed": "Validation(s) failed:",
   "errors": {
     "VLD_000": "Draft is currently not expecting actions",

--- a/src/languages/es_ES.json
+++ b/src/languages/es_ES.json
@@ -127,6 +127,7 @@
   "<0></0>BAN": "<0></0>BAN",
   "flip": "Voltear posiciones de Anfitrión e Invitado",
   "smooch": "Alternar el modo de beso",
+  "simplifiedUI": "Alternar Interfaz Simplificada",
   "validationFailed": "Fallaron la/s validaciónes:",
   "errors": {
     "VLD_000": "El Draft no esta esperando acciónes",

--- a/src/languages/es_ES.json
+++ b/src/languages/es_ES.json
@@ -126,8 +126,8 @@
   "<0></0>PICK": "<0></0>PICK",
   "<0></0>BAN": "<0></0>BAN",
   "flip": "Voltear posiciones de Anfitrión e Invitado",
-  "smooch": "Alternar el modo de beso",
-  "simplifiedUI": "Alternar Interfaz Simplificada",
+  "smooch": "Modo de beso",
+  "simplifiedUI": "Interfaz Simplificada",
   "validationFailed": "Fallaron la/s validaciónes:",
   "errors": {
     "VLD_000": "El Draft no esta esperando acciónes",

--- a/src/sass/bulma-dark-switch.sass
+++ b/src/sass/bulma-dark-switch.sass
@@ -1,0 +1,68 @@
+$switch-background: $grey-dark
+
+=switch-size($size)
+  + label
+
+    &::before,
+    &:before
+      background: $switch-background
+
+  &.is-outlined
+    + label
+      &::before,
+      &:before
+        border-color: $switch-background
+      &::after,
+      &:after
+        background: $switch-background
+
+
+.switch[type="checkbox"]
+
+  +switch-size($size-normal)
+  &.is-small
+    +switch-size($size-small)
+  &.is-medium
+    +switch-size($size-medium)
+  &.is-large
+    +switch-size($size-large)
+
+  @each $name, $pair in $colors
+    $color: nth($pair, 1)
+    $color-invert: nth($pair, 2)
+    &.is-#{$name}
+      &:checked
+        + label
+          &::before,
+          &:before
+            background: $color
+      &.is-outlined
+        &:checked
+          + label
+            &::before,
+            &:before
+              background-color: transparent
+              border-color: $color !important
+            &::after,
+            &:after
+              background: $color
+      &.is-thin
+        &.is-outlined
+          + label
+            &::after,
+            &:after
+              box-shadow: none
+    &.is-unchecked-#{$name}
+      + label
+        &::before,
+        &:before
+          background: $color
+      &.is-outlined
+        + label
+          &::before,
+          &:before
+            background-color: transparent
+            border-color: $color !important
+          &::after,
+          &:after
+            background: $color

--- a/src/sass/bulma-dark-switch.sass
+++ b/src/sass/bulma-dark-switch.sass
@@ -11,11 +11,20 @@ $switch-background: $grey-dark
     + label
       &::before,
       &:before
+        background-color: transparent
         border-color: $switch-background
       &::after,
       &:after
         background: $switch-background
-
+    &:checked
+      + label
+        &::before,
+        &:before
+          background-color: transparent
+          border-color: $switch-background-active
+        &::after,
+        &:after
+          background: $switch-paddle-background-active
 
 .switch[type="checkbox"]
 

--- a/src/sass/bulma-dark.scss
+++ b/src/sass/bulma-dark.scss
@@ -168,3 +168,4 @@ hr {
 }
 
 @import "bulma-dark-tags";
+@import "bulma-dark-switch";

--- a/src/sass/bulma.scss
+++ b/src/sass/bulma.scss
@@ -35,6 +35,7 @@ $steal-by-opponent: linear-gradient(135deg, $opponent-purple 33%, $steal-gold 34
 $family-monospace: 'Consolas', 'Monaco', monospace;
 
 @import "../../node_modules/bulma/bulma.sass";
+@import "../../node_modules/bulma-switch/src/sass/index.sass";
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
 //@import url('https://fonts.googleapis.com/css2?family=Crete+Round:ital@0;1&display=swap');

--- a/src/sass/bulma.scss
+++ b/src/sass/bulma.scss
@@ -801,10 +801,6 @@ html.has-simple-ui {
     padding: 0;
   }
 
-  //.pick {
-  //  background: #0084AC; // T90 Blue
-  //}
-
   #player-guest.column, #player-host.column {
     margin: 0;
     padding: 0.7rem;

--- a/src/sass/bulma.scss
+++ b/src/sass/bulma.scss
@@ -774,3 +774,41 @@ html.has-theme-dark {
 body.has-theme-dark {
   @import "bulma-dark.scss";
 }
+
+// Simple UI
+html.has-theme-simple-ui {
+  background: none;
+
+  body.simple-ui {
+    background: none;
+  }
+
+  .box {
+    background: none !important;
+    box-shadow: none;
+  }
+
+  .ban {
+    width: 96px;
+    height: 96px;
+  }
+
+  .player.box {
+    width: 650px;
+    padding: 0;
+  }
+
+  //.pick {
+  //  background: #0084AC; // T90 Blue
+  //}
+
+  #player-guest.column, #player-host.column {
+    margin: 0;
+    padding: 0.7rem;
+  }
+
+  .footer {
+    background: none;
+    opacity: 80%;
+  }
+}

--- a/src/sass/bulma.scss
+++ b/src/sass/bulma.scss
@@ -777,10 +777,10 @@ body.has-theme-dark {
 }
 
 // Simple UI
-html.has-theme-simple-ui {
+html.has-simple-ui {
   background: none;
 
-  body.simple-ui {
+  body.has-simple-ui {
     background: none;
   }
 

--- a/src/sass/bulma.scss
+++ b/src/sass/bulma.scss
@@ -35,6 +35,8 @@ $steal-by-opponent: linear-gradient(135deg, $opponent-purple 33%, $steal-gold 34
 $family-monospace: 'Consolas', 'Monaco', monospace;
 
 @import "../../node_modules/bulma/bulma.sass";
+
+$switch-focus: none;
 @import "../../node_modules/bulma-switch/src/sass/index.sass";
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
@@ -780,7 +782,7 @@ body.has-theme-dark {
 html.has-simple-ui {
   background: none;
 
-  body.has-simple-ui {
+  body {
     background: none;
   }
 

--- a/src/util/ColorSchemeHelpers.ts
+++ b/src/util/ColorSchemeHelpers.ts
@@ -37,12 +37,20 @@ class ColorSchemeHelpers {
             colorScheme = ColorSchemeHelpers.getOSColorSchemePreference()
         }
         if (colorScheme === ColorScheme.DARK) {
-            document.documentElement.classList.add('has-theme-dark');
-            document.body.classList.add('has-theme-dark');
+            this.addThemeClassName('has-theme-dark');
         } else {
-            document.documentElement.classList.remove('has-theme-dark');
-            document.body.classList.remove('has-theme-dark');
+            this.removeThemeClassName('has-theme-dark');
         }
+    }
+
+    public static addThemeClassName(className: string) {
+        document.documentElement.classList.add(className);
+        document.body.classList.add(className);
+    }
+
+    public static removeThemeClassName(className: string) {
+        document.documentElement.classList.remove(className);
+        document.body.classList.remove(className);
     }
 
 }


### PR DESCRIPTION
## Background

Many streamers use this app in some fashion to show the drafts to their viewers. They usually have to share the entire browser window with this app open. They would ideally like to embed / plug this in to their overlay, however it is not easy to seamlessly integrate this app using OBS unless we make some changes to the UI. 

### Implementation

- Add a toggle on the drafts page to set the page to a "Simplified UI"
- When on this UI, the background of the page is transparent (required for OBS)
- Group the pick and ban boxes for each player
- Fix the grid to 5×n
- Hide the Civ picker and other status headings

### Future Improvements
- [x] Show a toggle to show the current state of toggles
- [ ] Provide few URL params to customize the look and feel of the page to match the streamer's branding colors.

https://user-images.githubusercontent.com/13775/111333700-ed573b00-8698-11eb-9d80-6fc99e96f0ea.mov
