### PR TITLE
Allow customization of the Drafts page using URL Params

### DIFF
--- a/src/components/draft/CivPanel.tsx
+++ b/src/components/draft/CivPanel.tsx
@@ -25,7 +25,7 @@ interface IProps extends WithTranslation {
     draft?: IDraftState;
     nextAction: number;
     iconStyle: string;
-
+    color?: string;
     onClickCivilisation?: (playerEvent: PlayerEvent, callback: any) => void;
 }
 
@@ -121,7 +121,7 @@ class CivPanel extends React.Component<IProps, IState> {
         }
         return (
             <div className={className} onClick={onClickAction}>
-                <div className={'stretchy-background'}/>
+                <div className={'stretchy-background'} style={this.props.color ? {backgroundColor: this.props.color} : {}}/>
                 <div className={contentClass}>
                     <div className="stretchy-wrapper">
                         <div className={imageContainerClass}>

--- a/src/components/draft/CivPanel.tsx
+++ b/src/components/draft/CivPanel.tsx
@@ -25,7 +25,7 @@ interface IProps extends WithTranslation {
     draft?: IDraftState;
     nextAction: number;
     iconStyle: string;
-    color?: string;
+    userThemecolor?: string;
     onClickCivilisation?: (playerEvent: PlayerEvent, callback: any) => void;
 }
 
@@ -121,7 +121,7 @@ class CivPanel extends React.Component<IProps, IState> {
         }
         return (
             <div className={className} onClick={onClickAction}>
-                <div className={'stretchy-background'} style={this.props.color ? {backgroundColor: this.props.color} : {}}/>
+                <div className={'stretchy-background'} style={this.props.userThemecolor ? {backgroundColor: this.props.userThemecolor} : {}}/>
                 <div className={contentClass}>
                     <div className="stretchy-wrapper">
                         <div className={imageContainerClass}>

--- a/src/components/draft/Draft.tsx
+++ b/src/components/draft/Draft.tsx
@@ -54,6 +54,8 @@ interface IState {
     flipped: boolean;
     smooch: boolean;
     simplifiedUI: boolean;
+    userTheme?: {};
+    colorBan?: string;
 }
 
 class Draft extends React.Component<IProps, IState> {
@@ -65,6 +67,24 @@ class Draft extends React.Component<IProps, IState> {
         const smooch = query.get('smooch') === 'true' || false;
         const simplifiedUI = query.get('simplified') === 'true' || false;
         this.state = {joined: false, flipped, smooch, simplifiedUI};
+
+        // Custom User Theme Colors passed via URL params
+        let userTheme = {};
+
+        const colorPick = query.get('color_pick');
+        if (colorPick && colorPick.match(/^[A-F0-9]{6}$/gi)) {
+            userTheme['colorPick'] = "#"+colorPick;
+        }
+
+        const colorBan = query.get('color_ban');
+        if (colorBan && colorBan.match(/^[A-F0-9]{6}$/gi)) {
+            userTheme['colorBan'] = "#"+colorBan;
+        }
+
+        if (Object.keys(userTheme).length > 0) {
+            console.info("Custom User Theme", userTheme);
+            this.state = {...this.state, userTheme}
+        }
     }
 
 
@@ -192,7 +212,9 @@ class Draft extends React.Component<IProps, IState> {
 
                     <DraftState nameHost={this.props.nameHost} nameGuest={this.props.nameGuest}
                                 preset={this.props.preset}
-                                simplifiedUI={this.state.simplifiedUI} />
+                                simplifiedUI={this.state.simplifiedUI}
+                                userTheme={this.state.userTheme}
+                    />
 
                     <div className="columns is-mobile">
                         <div id="action-text" className="column has-text-centered is-size-4">

--- a/src/components/draft/DraftState.tsx
+++ b/src/components/draft/DraftState.tsx
@@ -8,6 +8,7 @@ interface IProps {
     nameGuest: string;
     preset: Preset;
     simplifiedUI: boolean;
+    userTheme?: {};
 }
 
 class DraftState extends React.Component<IProps, object> {
@@ -18,12 +19,14 @@ class DraftState extends React.Component<IProps, object> {
                                   player={ModelPlayer.HOST}
                                   name={this.props.nameHost}
                                   key={ModelPlayer.HOST}
-                                  simplifiedUI={this.props.simplifiedUI}/>
+                                  simplifiedUI={this.props.simplifiedUI}
+                                  userTheme={this.props.userTheme}/>
                 <PlayerDraftState preset={this.props.preset}
                                   player={ModelPlayer.GUEST}
                                   name={this.props.nameGuest}
                                   key={ModelPlayer.GUEST}
-                                  simplifiedUI={this.props.simplifiedUI}/>
+                                  simplifiedUI={this.props.simplifiedUI}
+                                  userTheme={this.props.userTheme}/>
             </div>
         );
     }

--- a/src/components/draft/PlayerDraftState.tsx
+++ b/src/components/draft/PlayerDraftState.tsx
@@ -19,6 +19,7 @@ interface IProps extends WithTranslation {
     nextAction?: number;
     events?: DraftEvent[];
     simplifiedUI?: boolean
+    userTheme?: {};
 }
 
 interface IState {
@@ -73,6 +74,7 @@ class PlayerDraftState extends React.Component<IProps, IState> {
                         civPanelType: CivPanelType.PICK,
                         civilisation: pickedCiv,
                         key: picksIndex,
+                        color: this.props.userTheme && this.props.userTheme['colorPick'],
                         sniped,
                         stolen
                     }));
@@ -108,6 +110,7 @@ class PlayerDraftState extends React.Component<IProps, IState> {
                         byOpponent: turn.player !== turn.executingPlayer,
                         civPanelType: CivPanelType.BAN,
                         civilisation: bannedCiv,
+                        color: this.props.userTheme && this.props.userTheme['colorBan'],
                         key: bansIndex,
                     }));
 


### PR DESCRIPTION
## Summary
Allow any user to customize the look and feel of the Drafts page by passing color codes via URL params. This is helpful for streamers who would want to use brand colors on the drafts page for their stream.

### Currently supported URL Params
1. `color_pick` - Hex color code of the border of Pick box without the `#` prefix. eg. `color_pick=0084AC`
1. `color_ban` - Hex color code of the border of Ban box without the `#` prefix. eg. `color_ban=0084AC`

### Example URL
```
http://localhost:3001/draft/WlQaG?color_pick=0084AC&color_ban=008400
```