### PR TITLE
Add IDs to pieces of drafting UI

### DIFF
--- a/src/components/draft/Draft.tsx
+++ b/src/components/draft/Draft.tsx
@@ -197,7 +197,7 @@ class Draft extends React.Component<IProps, IState> {
                                 smooch={this.state.smooch}
                                 simplifiedUI={this.state.simplifiedUI}/>
 
-                    <div className="columns is-mobile">
+                    <div id="messages" className="columns is-mobile">
                         <div id="action-text" className="column has-text-centered is-size-4">
                             <Messages/>
                         </div>
@@ -211,7 +211,7 @@ class Draft extends React.Component<IProps, IState> {
                 </div>
             </section>
 
-            <section className="section pt-0">
+            <section id="toggles" className="section pt-0">
                 <div className="container is-mobile has-text-centered">
                     <div className="field is-grouped is-grouped-centered">
                         <p className="control">
@@ -239,7 +239,7 @@ class Draft extends React.Component<IProps, IState> {
                 </div>
             </section>
 
-            {!this.state.simplifiedUI && <section className="section pt-0">
+            {!this.state.simplifiedUI && <section id="how-it-works" className="section pt-0">
                 <div className="container is-desktop has-text-centered" style={{maxWidth: "808px"}}>
                     <details>
                         <summary className="has-cursor-pointer"><Trans i18nKey='menu.howItWorks'>How it works</Trans></summary>

--- a/src/components/draft/DraftIdInfo.tsx
+++ b/src/components/draft/DraftIdInfo.tsx
@@ -22,7 +22,7 @@ class DraftIdInfo extends React.Component<IProps, object> {
         const i18nKey = this.hasDraftEnded() ? 'codeInstructionsAfter' : 'codeInstructionsBefore';
 
         return (
-            <div className="columns is-mobile">
+            <div id="draft-id-info" className="columns is-mobile">
                 <div className="column has-text-centered">
                     <CopyableInput content={Util.getIdFromUrl()} before={i18nKey} length={10} classes={"is-small is-valinged-middle"}/>
                 </div>

--- a/src/components/draft/ReplayControls.tsx
+++ b/src/components/draft/ReplayControls.tsx
@@ -70,7 +70,7 @@ class ReplayControls extends React.Component<IProps, IState> {
                                       onClick={this.restart} aria-label="Restart">
             <RestartIcon size={48} /></button>;
 
-        return <div className="columns is-mobile">
+        return <div id="replay-controls" className="columns is-mobile">
             <div className="column has-text-centered">
                 <div id="spectator-controls" className="buttons is-centered">
                     {this.hasDraftEnded() ? null : this.state.isRunning ? pauseButton : runButton}


### PR DESCRIPTION
There's a bunch of work that could be done to allow broadcasters to use aoe2cm live on stream better than just a desktop/window capture of the browser. The raw website has lots of extra elements/controls you don't want viewers to see on stream and simplified mode removes some useful UI parts and not some of the not useful parts that I'd want to remove.

So, one option for these broadcasters is to use OBS browser sources' "custom css" box to force some CSS onto the drafting page.

I have attempted this to a reasonable result, but the CSS I've had to use is _not pretty_:
```css
body, html, footer.footer { background-color: rgba(0, 0, 0, 0); margin: 0px auto;  overflow-y: hidden; overflow-x: hidden; }
#root > nav { display: none; }
section.section.pt-0 { display: none; } /* removes the toggle controls */
div#spectator-controls { display: none; } /* removes spectator controls */
.back-icon > svg { display: none; }
body .box { background-color: rgba(0.8, 0.8, 0.8, 0.4); color: #b5b5b5; }
div#container :nth-child(6) { display: none; }
html > body, #draft-title a, footer.footer { color: white; }
```
Notably trying to get the colours as I want them (dark/light mode is a bit wonky in browser sources), remove nav, and any other settings/toggles etc.

Perhaps in the future this could be turned into a feature request for a "stream-friendly mode" or similar, but for now - just making some of the UI elements more easily targetable by this kind of CSS would be good (note the nth child selector, which only works during a live draft and not after one finishes).