### PR TITLE
Replace Button Set with Tabs in Preset Creator

### DIFF
--- a/src/components/PresetEditor/PresetEditor.tsx
+++ b/src/components/PresetEditor/PresetEditor.tsx
@@ -28,8 +28,10 @@ import PresetEditorCustomOptions from "./PresetEditorCustomOptions";
 import Civilisation from "../../models/Civilisation";
 import Aoe3Civilisation from "../../models/Aoe3Civilisation";
 import Aoe4Civilisation from "../../models/Aoe4Civilisation";
+import {RouteComponentProps} from "react-router";
+import CivilisationSet from "../../models/CivilisationSet";
 
-interface Props extends WithTranslation{
+interface Props extends WithTranslation, RouteComponentProps<any>{
     preset: Preset | null,
     onSetEditorPreset: (preset: Preset) => ISetEditorPreset,
     onValueChange: (turn: Turn | null, index: number) => ISetEditorTurn,
@@ -39,14 +41,15 @@ interface Props extends WithTranslation{
 }
 
 interface State {
-    defaultDraftOptions: DraftOption[]
+    defaultDraftOptions: DraftOption[],
+    activeCivilisationSet: String
 }
 
 class PresetEditor extends React.Component<Props, State> {
 
     constructor(props: Props) {
         super(props);
-        this.state = {defaultDraftOptions: Civilisation.ALL};
+        this.state = {defaultDraftOptions: Civilisation.ALL, activeCivilisationSet: CivilisationSet.AOE2};
     }
 
     componentDidMount(): void {
@@ -54,6 +57,22 @@ class PresetEditor extends React.Component<Props, State> {
             this.props.onSetEditorPreset(Preset.NEW);
         }
         document.title = 'Preset Editor – AoE2 Captains Mode';
+        const civs = (this.props.location.hash || CivilisationSet.AOE2).replace("#", '');
+        switch (civs) {
+            default:
+            case CivilisationSet.AOE2:
+                this.setState({defaultDraftOptions: Civilisation.ALL, activeCivilisationSet: CivilisationSet.AOE2});
+                break;
+            case CivilisationSet.AOE3:
+                this.setState({defaultDraftOptions: Aoe3Civilisation.ALL, activeCivilisationSet: CivilisationSet.AOE3});
+                break;
+            case CivilisationSet.AOE4:
+                this.setState({defaultDraftOptions: Aoe4Civilisation.ALL, activeCivilisationSet: CivilisationSet.AOE4});
+                break;
+            case CivilisationSet.CUSTOM:
+                this.setState({defaultDraftOptions: [], activeCivilisationSet: CivilisationSet.CUSTOM});
+                break;
+        }
     }
 
     public render() {
@@ -75,31 +94,46 @@ class PresetEditor extends React.Component<Props, State> {
                 <div className={'content box'}>
                     <h3>1. <Trans i18nKey="presetEditor.availableDraftOptions">Available Draft Options</Trans></h3>
 
-                    <p className="control">
-                        <button className="button" onClick={()=>{
-                            this.setState({defaultDraftOptions: Civilisation.ALL});
-                            this.props.onPresetDraftOptionsChange([...Civilisation.ALL]);
-                        }}><Trans i18nKey="presetEditor.aoe2Civs">AoE2 civs</Trans></button>
-
-                        <button className="button" onClick={()=>{
-                            this.setState({defaultDraftOptions: Aoe3Civilisation.ALL});
-                            this.props.onPresetDraftOptionsChange([...Aoe3Civilisation.ALL]);
-                        }}><Trans i18nKey="presetEditor.aoe3Civs">AoE3 civs</Trans></button>
-
-                        <button className="button" onClick={()=>{
-                            this.setState({defaultDraftOptions: Aoe4Civilisation.ALL});
-                            this.props.onPresetDraftOptionsChange([...Aoe4Civilisation.ALL]);
-                        }}><Trans i18nKey="presetEditor.aoe4Civs">AoE4 civs</Trans></button>
-
-                        <button className="button" onClick={()=>{
-                            this.setState({defaultDraftOptions: []});
-                            const draftOption = new DraftOption(Civilisation.AZTECS.id, Civilisation.AZTECS.name);
-                            for (let imageUrlsKey in draftOption.imageUrls) {
-                                draftOption.imageUrls[imageUrlsKey] = 'https://aoe2cm.net' + draftOption.imageUrls[imageUrlsKey];
-                            }
-                            this.props.onPresetDraftOptionsChange([draftOption]);
-                        }}><Trans i18nKey="presetEditor.customOptions">Custom</Trans></button>
-                    </p>
+                    <div className="tabs is-boxed is-small civ-selector-tabs">
+                        <ul>
+                            <li className={this.state.activeCivilisationSet === CivilisationSet.AOE2 ? "is-active" : ""}>
+                                <a href="#aoe2" onClick={()=>{
+                                    this.setState({defaultDraftOptions: Civilisation.ALL, activeCivilisationSet: CivilisationSet.AOE2});
+                                    this.props.onPresetDraftOptionsChange([...Civilisation.ALL]);
+                                }}>
+                                    <Trans i18nKey="presetEditor.aoe2Civs">AoE2 civs</Trans>
+                                </a>
+                            </li>
+                            <li className={this.state.activeCivilisationSet === CivilisationSet.AOE3 ? "is-active" : ""}>
+                                <a href="#aoe3" onClick={()=>{
+                                    this.setState({defaultDraftOptions: Aoe3Civilisation.ALL, activeCivilisationSet: CivilisationSet.AOE3});
+                                    this.props.onPresetDraftOptionsChange([...Aoe3Civilisation.ALL]);
+                                }}>
+                                    <Trans i18nKey="presetEditor.aoe3Civs">AoE3 civs</Trans>
+                                </a>
+                            </li>
+                            <li className={this.state.activeCivilisationSet === CivilisationSet.AOE4 ? "is-active" : ""}>
+                                <a href="#aoe4" onClick={()=>{
+                                    this.setState({defaultDraftOptions: Aoe4Civilisation.ALL, activeCivilisationSet: CivilisationSet.AOE4});
+                                    this.props.onPresetDraftOptionsChange([...Aoe4Civilisation.ALL]);
+                                }}>
+                                    <Trans i18nKey="presetEditor.aoe4Civs">AoE4 civs</Trans>
+                                </a>
+                            </li>
+                            <li className={this.state.activeCivilisationSet === CivilisationSet.CUSTOM ? "is-active" : ""}>
+                                <a href="#custom" onClick={()=>{
+                                    this.setState({defaultDraftOptions: [], activeCivilisationSet: CivilisationSet.CUSTOM});
+                                    const draftOption = new DraftOption(Civilisation.AZTECS.id, Civilisation.AZTECS.name);
+                                    for (let imageUrlsKey in draftOption.imageUrls) {
+                                        draftOption.imageUrls[imageUrlsKey] = 'https://aoe2cm.net' + draftOption.imageUrls[imageUrlsKey];
+                                    }
+                                    this.props.onPresetDraftOptionsChange([draftOption]);
+                                }}>
+                                    <Trans i18nKey="presetEditor.customOptions">Custom</Trans>
+                                </a>
+                            </li>
+                        </ul>
+                    </div>
 
                     {optionsSelection}
 

--- a/src/components/PresetEditor/PresetEditorCustomOptions.tsx
+++ b/src/components/PresetEditor/PresetEditorCustomOptions.tsx
@@ -26,15 +26,16 @@ class PresetEditorCustomOptions extends React.Component<Props, object> {
 
         const options = presetOptions.map((value: DraftOption, index: number) => <PresetOption draftOptionIndex={index}
                                                                                                key={index}/>);
-
         return (
             <>
-                <div className="notification is-primary">
-                    <Trans i18nKey="presetEditor.warning">
-                    <strong>Attention!</strong><br/>
-                    This is advanced stuff, and you probably do not need it if you just want to create a regular old civilisation draft.<br/>
-                    <strong>Please use image urls which you expect to still be working in about ten years or more!</strong>
-                    </Trans>
+                <div className="message is-warning">
+                    <div className="message-body">
+                        <Trans i18nKey="presetEditor.warning">
+                        <strong>Attention!</strong><br/>
+                        This is advanced stuff, and you probably do not need it if you just want to create a regular old civilisation draft.<br/>
+                        <strong>Please use image urls which you expect to still be working in about ten years or more!</strong>
+                        </Trans>
+                    </div>
                 </div>
                 <div>
                     <ReactSortable<DraftOption> list={presetOptions}

--- a/src/models/CivilisationSet.ts
+++ b/src/models/CivilisationSet.ts
@@ -1,0 +1,8 @@
+enum CivilisationSet {
+    AOE2 = "aoe2",
+    AOE3 = "aoe3",
+    AOE4 = "aoe4",
+    CUSTOM = "custom"
+}
+
+export default CivilisationSet;

--- a/src/sass/bulma-dark.scss
+++ b/src/sass/bulma-dark.scss
@@ -167,5 +167,20 @@ hr {
   color: $scheme-invert-ter;
 }
 
+.civ-selector-tabs.tabs.is-boxed {
+  ul {
+    li.is-active {
+      a, a:hover {
+        background-color: #242424;
+      }
+    }
+    li {
+      a:hover {
+        background-color: #363636;
+      }
+    }
+  }
+}
+
 @import "bulma-dark-tags";
 @import "bulma-dark-switch";

--- a/src/sass/bulma.scss
+++ b/src/sass/bulma.scss
@@ -905,3 +905,13 @@ html.has-simple-ui {
 .is-justify-content-center {
   justify-content: center;
 }
+
+.civ-selector-tabs {
+  ul {
+    margin-left: 0;
+    text-transform: uppercase;
+    li:first-child {
+      margin-left: 10px;
+    }
+  }
+}


### PR DESCRIPTION
### Before
![before](https://user-images.githubusercontent.com/13775/154920544-bc8562bf-487b-415b-90c6-b21dd921125c.png)

### After
![after](https://user-images.githubusercontent.com/13775/154920570-b6431ad2-af16-4d60-9870-cc7d32b66b0e.png)

### URL Hash
Also provide and ability to preselect a civ set based on the URL hash so we can add different `Create Preset` buttons for different editions.  Example:
```
https://aoe2cm.net/preset/create#aoe2
https://aoe2cm.net/preset/create#aoe3
https://aoe2cm.net/preset/create#aoe4
```