### PR TITLE
Prevent drafts that aren't started yet from being purged early on hourly interval

### DIFF
--- a/src/DraftServer.ts
+++ b/src/DraftServer.ts
@@ -246,6 +246,8 @@ export class DraftServer {
             if (!wasAlreadyReady && draftsStore.playersAreReady(draftId)) {
                 logger.info("Both Players are ready, starting countdown.", {draftId});
 
+                draftsStore.setStartTimestampIfNecessary(draftId);
+
                 const draftViews = draftsStore.getDraftViewsOrThrow(draftId);
                 let adminEventCounter = 0;
                 while (ActListener.nextActionIsAdminEvent(draftsStore, draftId, adminEventCounter)) {
@@ -266,7 +268,6 @@ export class DraftServer {
                 }
 
                 draftsStore.startCountdown(draftId, socket, this.currentDataDirectory);
-                draftsStore.setStartTimestampIfNecessary(draftId);
             }
             socket.nsp
                 .in(roomHost)

--- a/src/models/Draft.ts
+++ b/src/models/Draft.ts
@@ -26,7 +26,7 @@ class Draft implements IDraftState {
         this.guestConnected = false;
         this.hostReady = false;
         this.guestReady = false;
-        this.startTimestamp = 0;
+        this.startTimestamp = Date.now();
     }
 
     public static from(source: Draft): Draft {

--- a/src/models/DraftsStore.ts
+++ b/src/models/DraftsStore.ts
@@ -369,7 +369,7 @@ export class DraftsStore {
 
     public setStartTimestampIfNecessary(draftId: string) {
         const draft = this.getDraftOrThrow(draftId);
-        if (!draft.startTimestamp) {
+        if (!draft.startTimestamp || draft.nextAction === 0) {
             draft.startTimestamp = Date.now();
         }
     }

--- a/src/util/ActListener.ts
+++ b/src/util/ActListener.ts
@@ -209,7 +209,6 @@ export class ActListener {
                                   draftId: string, roomLobby: string, roomHost: string, roomGuest: string, roomSpec: string, dataDirectory: string) {
         if (!draftViews.getActualDraft().hasNextAction()) {
             const draft = draftsStore.getDraftOrThrow(draftId);
-            draft.startTimestamp = 0;
             draft.hostConnected = false;
             draft.guestConnected = false;
             logger.info("Saving draft: %s", JSON.stringify(draft), {draftId});

--- a/src/util/ActListener.ts
+++ b/src/util/ActListener.ts
@@ -12,6 +12,7 @@ import AdminEvent from "../models/AdminEvent";
 import path from "path";
 import {Socket} from "socket.io";
 import DraftOption from "../models/DraftOption";
+import Draft from "../models/Draft";
 
 export class ActListener {
     readonly dataDirectory: string;
@@ -211,9 +212,11 @@ export class ActListener {
             const draft = draftsStore.getDraftOrThrow(draftId);
             draft.hostConnected = false;
             draft.guestConnected = false;
-            logger.info("Saving draft: %s", JSON.stringify(draft), {draftId});
+            const savedDraft = Draft.from(draft);
+            savedDraft.startTimestamp = 0;
+            logger.info("Saving draft: %s", JSON.stringify(savedDraft), {draftId});
             const draftPath = path.join(dataDirectory, `${draftId}.json`);
-            fs.writeFile(draftPath, JSON.stringify(draft), (err) => {
+            fs.writeFile(draftPath, JSON.stringify(savedDraft), (err) => {
                 logger.info("No further action expected. Disconnecting clients.", {draftId});
                 for (let room of [roomHost, roomGuest, roomSpec]) {
                     socket.nsp.in(room).allSockets().then(


### PR DESCRIPTION
https://github.com/SiegeEngineers/aoe2cm2/blob/1196b85608a4fbafaf2c56dbd5f7decf27df971b/src/models/DraftsStore.ts#L465 checks startTimestamp, which can be 0 if the draft hasn't been started yet, so it'd purge such drafts instantly when purgeStaleDrafts runs. The purgeStaleDrafts runs on hourly interval.

Also made sure startTimestamp gets reset when the draft starts so the offsets in the saved file are correct.

Note that in `finishDraftIfNoFurtherActions` setting `startTimestamp` to 0 means that there's a potential (but very rare) race condition where the async writeFile could yield control to purgeStaleDrafts, before `finishDraft` is called. So removed setting that to 0.
