### PR TITLE
Add optional "participants" parameters to create draft API endpoint

### DIFF
--- a/src/models/Draft.ts
+++ b/src/models/Draft.ts
@@ -17,6 +17,7 @@ class Draft implements IDraftState {
     public nextAction: number = 0;
     public events: DraftEvent[] = [];
     public startTimestamp: number;
+    public fixedNames: boolean = false;
 
     constructor(nameHost: string, nameGuest: string, preset: Preset) {
         this.nameHost = nameHost;

--- a/src/models/DraftsStore.ts
+++ b/src/models/DraftsStore.ts
@@ -179,6 +179,11 @@ export class DraftsStore {
         }
     }
 
+    public setFixedPlayerNames(draftId: string, fixedNames: boolean) {
+        const draft: Draft = this.getDraftOrThrow(draftId);
+        draft.fixedNames = fixedNames;
+    }
+
     public setPlayerName(draftId: string, player: Player, name: string) {
         const draft: Draft = this.getDraftOrThrow(draftId);
         switch (player) {


### PR DESCRIPTION
Closes #128

There is a small UI glitch where the name will be set to the player's name and then instantly reverted to the fixed name of the draft.