### PR TITLE
Allow admin snipe steal

### DIFF
--- a/src/components/PresetEditor/ActionDropdown.tsx
+++ b/src/components/PresetEditor/ActionDropdown.tsx
@@ -25,6 +25,8 @@ class ActionDropdown extends React.Component<Props, object> {
             options.push(<option key={i++} value={Action.PAUSE}>{Action.PAUSE}</option>);
             options.push(<option key={i++} value={Action.PICK}>{Action.PICK}</option>);
             options.push(<option key={i++} value={Action.BAN}>{Action.BAN}</option>);
+            options.push(<option key={i++} value={Action.SNIPE}>{Action.SNIPE}</option>);
+            options.push(<option key={i++} value={Action.STEAL}>{Action.STEAL}</option>);
         } else {
             options.push(<option key={i++} value={Action.PICK}>{Action.PICK}</option>);
             options.push(<option key={i++} value={Action.BAN}>{Action.BAN}</option>);
@@ -36,8 +38,12 @@ class ActionDropdown extends React.Component<Props, object> {
                 const t = this.props.turn;
                 const newAction = event.target.value as Action;
                 let player = t.player;
-                if (t.executingPlayer === Player.NONE && ![Action.PICK, Action.BAN].includes(newAction)) {
-                    player = Player.NONE;
+                if (t.executingPlayer === Player.NONE) {
+                    if (![Action.PICK, Action.BAN, Action.SNIPE, Action.STEAL].includes(newAction)) {
+                        player = Player.NONE;
+                    } else if (player === Player.NONE && [Action.SNIPE, Action.STEAL].includes(newAction)) {
+                        player = Player.HOST;
+                    }
                 }
                 const newTurn = new Turn(player, newAction, t.exclusivity, t.hidden, t.parallel, t.executingPlayer);
                 this.props.onValueChange(newTurn, this.props.index)

--- a/src/components/PresetEditor/ActionDropdown.tsx
+++ b/src/components/PresetEditor/ActionDropdown.tsx
@@ -38,14 +38,16 @@ class ActionDropdown extends React.Component<Props, object> {
                 const t = this.props.turn;
                 const newAction = event.target.value as Action;
                 let player = t.player;
+                let hidden = t.hidden;
                 if (t.executingPlayer === Player.NONE) {
                     if (![Action.PICK, Action.BAN, Action.SNIPE, Action.STEAL].includes(newAction)) {
                         player = Player.NONE;
+                        hidden = false;
                     } else if (player === Player.NONE && [Action.SNIPE, Action.STEAL].includes(newAction)) {
                         player = Player.HOST;
                     }
                 }
-                const newTurn = new Turn(player, newAction, t.exclusivity, t.hidden, t.parallel, t.executingPlayer);
+                const newTurn = new Turn(player, newAction, t.exclusivity, hidden, t.parallel, t.executingPlayer);
                 this.props.onValueChange(newTurn, this.props.index)
             }}>{options}
             </select>

--- a/src/components/PresetEditor/AsPlayerDropdown.tsx
+++ b/src/components/PresetEditor/AsPlayerDropdown.tsx
@@ -26,7 +26,12 @@ class AsPlayerDropdown extends React.Component<Props, object> {
         return <div className="select is-small">
             <select value={this.props.turn.player} onChange={(event) => {
                 const t = this.props.turn;
-                const newTurn = new Turn((event.target.value as Player), t.action, t.exclusivity, t.hidden, t.parallel, t.executingPlayer);
+                const newPlayer = (event.target.value as Player);
+                let hidden = t.hidden;
+                if (newPlayer === Player.NONE) {
+                    hidden = false;
+                }
+                const newTurn = new Turn(newPlayer, t.action, t.exclusivity, hidden, t.parallel, t.executingPlayer);
                 this.props.onValueChange(newTurn, this.props.index)
             }}>{options}
             </select>

--- a/src/components/PresetEditor/AsPlayerDropdown.tsx
+++ b/src/components/PresetEditor/AsPlayerDropdown.tsx
@@ -16,8 +16,10 @@ class AsPlayerDropdown extends React.Component<Props, object> {
     render() {
         const options = [];
         let i = 0;
-        options.push(<option key={i++} value={Player.NONE}>{Player.NONE}</option>);
-        if ([Action.PICK, Action.BAN].includes(this.props.turn.action)) {
+        if (![Action.SNIPE, Action.STEAL].includes(this.props.turn.action)) {
+            options.push(<option key={i++} value={Player.NONE}>{Player.NONE}</option>);
+        }
+        if ([Action.PICK, Action.BAN, Action.SNIPE, Action.STEAL].includes(this.props.turn.action)) {
             options.push(<option key={i++} value={Player.HOST}>{Player.HOST}</option>);
             options.push(<option key={i++} value={Player.GUEST}>{Player.GUEST}</option>);
         }

--- a/src/components/PresetEditor/HiddenCheckbox.tsx
+++ b/src/components/PresetEditor/HiddenCheckbox.tsx
@@ -8,13 +8,14 @@ import {ISetEditorTurn} from "../../actions";
 interface Props {
     turn: Turn,
     index: number,
+    disabled?: boolean,
     onValueChange: (turn: Turn, index: number) => ISetEditorTurn
 }
 
 class HiddenCheckbox extends React.Component<Props, object> {
     render() {
         return <label className="checkbox tag has-background-transparent">
-            <input type='checkbox' checked={this.props.turn.hidden} onChange={() => {
+            <input type='checkbox' checked={this.props.turn.hidden} disabled={!!this.props.disabled} onChange={() => {
                 const t = this.props.turn;
                 const newTurn = new Turn(t.player, t.action, t.exclusivity, !t.hidden, t.parallel, t.executingPlayer);
                 this.props.onValueChange(newTurn, this.props.index)

--- a/src/components/PresetEditor/PlayerTurnSettings.tsx
+++ b/src/components/PresetEditor/PlayerTurnSettings.tsx
@@ -21,11 +21,14 @@ class PlayerTurnSettings extends React.Component<Props, object> {
             return null;
         }
         if (this.props.turn.executingPlayer === Player.NONE) {
+            const canHide = this.props.turn.player !== Player.NONE;
             return <div>
                 <ActionDropdown turn={this.props.turn} index={this.props.index}/>
                 <ExclusivityDropdown turn={this.props.turn} index={this.props.index}/>
-                <br/>
-                <AsPlayerDropdown turn={this.props.turn} index={this.props.index}/>
+                <div className="option-row">
+                    <HiddenCheckbox turn={this.props.turn} index={this.props.index} disabled={!canHide}/>
+                    <AsPlayerDropdown turn={this.props.turn} index={this.props.index}/>
+                </div>
                 <TurnCategoriesInput turn={this.props.turn} index={this.props.index} key={'tci'+this.props.index}/>
             </div>;
         }

--- a/src/languages/en_GB.json
+++ b/src/languages/en_GB.json
@@ -360,7 +360,7 @@
     "turnCategories": "Categories",
     "turnCategoriesAll": "all",
     "categoryLimits": "Category Limits",
-    "categoryLimitsExplanation": "Here you may, for each category, define a maximum number of times Draft Options from it can be picked or banned. Leave the input emtpy to set no limit for a category.",
+    "categoryLimitsExplanation": "Here you may, for each category, define a maximum number of times Draft Options from it can be picked or banned. Leave the input empty to set no limit for a category.",
     "categoryLimitsPick": "Pick",
     "categoryLimitsBan": "Ban",
     "createSaveDraft": "Create Draft or Save",

--- a/src/models/DraftViews.ts
+++ b/src/models/DraftViews.ts
@@ -79,8 +79,16 @@ class DraftViews {
                 this.hostEvents.push(specMessage);
             }
             if (draftEvent.executingPlayer === Player.NONE) {
-                this.guestEvents.push(draftEvent);
-                this.hostEvents.push(draftEvent);
+                if (draftEvent.player === Player.HOST) {
+                    this.hostEvents.push(draftEvent);
+                    this.guestEvents.push(specMessage);
+                } else if (draftEvent.player === Player.GUEST) {
+                    this.guestEvents.push(draftEvent);
+                    this.hostEvents.push(specMessage);
+                } else {
+                    this.guestEvents.push(draftEvent);
+                    this.hostEvents.push(draftEvent);
+                }
             }
         } else {
             this.hostEvents.push(draftEvent);

--- a/src/sass/bulma.scss
+++ b/src/sass/bulma.scss
@@ -925,6 +925,12 @@ img.directional {
   border-bottom: 1px solid darken($scheme-main-ter, 10%);
 }
 
+.preset-editor-row .option-row {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
 .has-background-transparent {
   background-color: transparent !important;
 }


### PR DESCRIPTION
For KCIP tourney with reverse picks they wanted a random steal. Apparently the backend already allows it, just the preset build ui doesn't.
This PR changes the UI code to allow admin to execute a SNIPE or STEAL action for either HOST or GUEST (but not NONE).

Tested locally.

I also created the following presets via the API by simply changing executingPlayer to NONE, but without HIDDEN:
- https://aoe2cm.net/preset/WNsVl
- https://aoe2cm.net/preset/fhvMH
- https://aoe2cm.net/preset/kXGdF

Note: When switching admin step to SNIPE or STEAL and the player NONE is selected, it'll automatically pick HOST.

One problem with this mechanism is that it's possible to random the previous steal. So it could randomly steal back.
So I ALSO had to allow admin steps to be hidden, with the appropriate backend change. By setting the step as hidden, it'll hide the 'steal' from the opponent, meaning both steals act on only the options already revealed.
