### PR TITLE
HIDDEN GLOBAL pick with AS_OPPONENT active should allow duplicate civ picks

### DIFF
--- a/src/models/Validation.ts
+++ b/src/models/Validation.ts
@@ -81,7 +81,7 @@ export class Validation {
 
         if (Util.isPlayerEvent(draftEvent)) {
             const draftViews = Validation.toDraftViews(draft);
-            let draftCopy = (draftEvent.player === Player.HOST) ? draftViews.getHostDraft() : draftViews.getGuestDraft();
+            let draftCopy = (draftEvent.executingPlayer === Player.HOST) ? draftViews.getHostDraft() : draftViews.getGuestDraft();
             const validCivs = new ValidCivs(draftCopy);
             return validCivs.validateDraftEvent(draftEvent);
         }


### PR DESCRIPTION
In a HIDDEN GLOBAL draft, you are able to pick duplicate civs as you don't know whether is already picked or not.

When drafting with AS_OPPONENT on, you are unable to pick a duplicate civ which is inconsistent with the previous example.

This should use the proper draft state to check whether you can pick the civ or not, since you should use the draftView of the executingPlayer.